### PR TITLE
Add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: cpp
+compiler:
+  - gcc
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq
+install:
+  - sudo apt-get install nasm gcc-multilib grub-common xorriso
+script:
+  - make
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/f81ab75718a4086bd0e8


### PR DESCRIPTION
Adds a very simple Travis config.  
Sends notifications to our Gitter. Uses the legacy infrastructure due to restrictions of apt packages.
Sample build: https://travis-ci.org/langerhans/TwitchOS/builds/88677187